### PR TITLE
refactor: rename single-word skills to syner-* and deduplicate note conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,19 @@ This gives Syner the context it needs to understand your notes properly.
 
 ### Knowledge
 
-- `/state` - Load your full notes state
+- `/syner-load-all` - Load your full notes state
 - `/syner-track-idea` - Track idea evolution (proactive + manual)
 
 ### Apps
 
 - `/create-syner-app` - Scaffold new applications with the standard stack (Next.js + TypeScript + Tailwind + shadcn)
 - `/update-syner-app` - Update existing apps to match current stack standards
+
+### Synthesis
+
+- `/syner-find-ideas` - Generate ideas from your knowledge
+- `/syner-find-links` - Find bridges between two different domains
+- `/syner-grow-note` - Promote a thought into a proper document
 
 ### Backlog
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Syner
 
-Your notes are your external brain. Syner makes them actionable.
+Your notes accumulate knowledge. Syner reads them as context and helps you connect, synthesize, and act on what you already know.
 
 Write markdown in `apps/notes/content/`. No schemas, no config. Then:
 
@@ -15,11 +15,11 @@ Write markdown in `apps/notes/content/`. No schemas, no config. Then:
 /syner what should I work on next?
 ```
 
-## Principles
+## Features
 
-- **Notes are personal** — free-form, no enforced structure ([PHILOSOPHY.md](PHILOSOPHY.md))
-- **Suggest, don't enforce** — skills recommend, you decide
-- **Action, Verify, Repeat** — agents execute with verification loops
+- **Knowledge as context** — your notes feed every skill, connections surface automatically
+- **Synthesis on demand** — generate ideas, find bridges between domains, grow scattered thoughts into documents
+- **Agentic execution** — tasks run with verification loops, not blind automation ([PHILOSOPHY.md](PHILOSOPHY.md))
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Syner
 
-Your notes accumulate knowledge. Syner reads them as context and helps you connect, synthesize, and act on what you already know.
+The open-source PKMS that reads your notes and helps you think, connect, and ship.
 
 Write markdown in `apps/notes/content/`. No schemas, no config. Then:
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,16 @@
 
 # Syner
 
-A runtime for your personal knowledge — notes go in, thinking and action come out.
+A personal knowledge runtime — agent skills that think with your notes.
 
 ## How it works
 
 Everything starts with your notes. Write markdown in `apps/notes/content/` — any structure, no schemas, no config. Your notes become the shared context that powers everything else.
 
-Skills read that context and do specific things with it: find ideas, connect domains, grow a thought into a full document. You invoke them directly or let the orchestrator route for you.
-
-Agents handle the heavy lifting. When a task needs multiple steps, they execute with verification loops — action, verify, repeat — until the job is done.
+Skills read that context and act on it — find ideas, connect domains, grow a thought into a full document. You invoke them directly or let the orchestrator route for you. When a task needs multiple steps, agents take over organically, executing with verification loops until the job is done.
 
 ```
-/syner what should I work on next?
+/syner anything new worth exploring?
 ```
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -7,61 +7,43 @@
 
 # Syner
 
-Your notes are your external brain. Syner is the interface that makes them actionable.
+Your notes are your external brain. Syner makes them actionable.
 
-## Why
+Write markdown in `apps/notes/content/`. No schemas, no config. Then:
 
-You accumulate knowledge across notes, ideas, and projects — but it stays scattered. Syner reads your notes as context, understands your situation, and helps you act on what you already know. No schemas, no config files, no enforced structure. Just markdown.
-
-## Quick Start
-
-```bash
-# 1. Write notes in markdown
-apps/notes/content/
-
-# 2. Ask syner anything
-/syner what should I work on next?
-
-# 3. Or use a skill directly
-/syner-find-ideas developer-tools
 ```
-
-That's it. The more you write, the more Syner understands.
+/syner what should I work on next?
+```
 
 ## Principles
 
-- **Notes are personal** — no enforced schema, no structured metadata. Syner reads for context, not data extraction
+- **Notes are personal** — free-form, no enforced structure ([PHILOSOPHY.md](PHILOSOPHY.md))
 - **Suggest, don't enforce** — skills recommend, you decide
-- **Execute with verification** — Action, Verify, Repeat
-
-See [PHILOSOPHY.md](PHILOSOPHY.md) for the full rationale.
-
-## Notes
-
-Markdown is the language of agents. Create notes in `apps/notes/content/` with any structure you like.
-
-To give Syner context about a folder, add an `index.md`. See [note-conventions.md](skills/syner/note-conventions.md) for the full reading conventions.
+- **Action, Verify, Repeat** — agents execute with verification loops
 
 ## Skills
 
-| Skill | What it does | Category |
-|-------|-------------|----------|
-| `/syner` | Orchestrator — understands context, routes to specialists or executes directly | Core |
-| `/syner-load-all` | Load your full notes state | Knowledge |
-| `/syner-track-idea` | Track idea evolution (proactive + manual) | Knowledge |
-| `/syner-find-ideas` | Generate ideas from your knowledge | Synthesis |
-| `/syner-find-links` | Find bridges between two different domains | Synthesis |
-| `/syner-grow-note` | Promote a thought into a proper document | Synthesis |
-| `/create-syner-app` | Scaffold new app with standard stack | Apps |
-| `/update-syner-app` | Update existing app to current standards | Apps |
-| `/backlog-triager` | Triage backlog items against codebase | Backlog |
-| `/backlog-reviewer` | Audit backlog health (stale, duplicates, hidden TODOs) | Backlog |
-| `/syner-enhance-skills` | Improve existing skills with best practices | Meta |
-| `/syner-researcher` | Research a topic from any source | Meta |
+| Skill | What it does |
+|-------|-------------|
+| `/syner` | Orchestrator — routes to specialists or executes directly |
+| `/syner-load-all` | Load your full notes state |
+| `/syner-find-ideas` | Generate ideas from your knowledge |
+| `/syner-find-links` | Find bridges between two domains |
+| `/syner-grow-note` | Promote a thought into a document |
+| `/syner-track-idea` | Track how an idea evolved over time |
+| `/create-syner-app` | Scaffold new app with standard stack |
+| `/update-syner-app` | Update app to current standards |
+| `/backlog-triager` | Triage backlog against codebase |
+| `/backlog-reviewer` | Audit backlog health |
+| `/syner-enhance-skills` | Improve an existing skill |
+| `/syner-researcher` | Research a topic from any source |
 
 ## Agents
 
-Agents handle complex execution with verification loops.
-
-- **syner-worker** — Executes tasks using workflow patterns (chaining, parallelization, routing). Action, Verify, Repeat
+- **syner-worker** — Executes tasks with workflow patterns (chaining, parallelization, routing)
 - **code-reviewer** — Reviews code for quality, security, and best practices
+
+## References
+
+- [PHILOSOPHY.md](PHILOSOPHY.md) — Design principles
+- [note-conventions.md](skills/syner/note-conventions.md) — How skills read your notes

--- a/README.md
+++ b/README.md
@@ -7,68 +7,61 @@
 
 # Syner
 
-A Personal Knowledge System
+Your notes are your external brain. Syner is the interface that makes them actionable.
 
-## Overview
+## Why
 
-Syner is an AI-powered personal knowledge system that understands how you think, follows your rules, and learns from your experiences to help you make better decisions.
+You accumulate knowledge across notes, ideas, and projects — but it stays scattered. Syner reads your notes as context, understands your situation, and helps you act on what you already know. No schemas, no config files, no enforced structure. Just markdown.
 
-Your notes become a living context that AI can read, trace, and connect - turning scattered thoughts into actionable insights.
+## Quick Start
 
-See [PHILOSOPHY.md](PHILOSOPHY.md) for the design principles behind Syner.
+```bash
+# 1. Write notes in markdown
+apps/notes/content/
 
-## Memory
+# 2. Ask syner anything
+/syner what should I work on next?
 
-Markdown is the language of agents.
+# 3. Or use a skill directly
+/syner-find-ideas developer-tools
+```
 
-Create notes in `apps/notes/` with any structure you like. The project starts blank with no predefined notes.
+That's it. The more you write, the more Syner understands.
 
-Each folder is an organization of notes. To give Syner context about a folder, create an `index.md` file that describes what that folder contains and how to interpret its contents.
+## Principles
 
-### The index.md Convention
+- **Notes are personal** — no enforced schema, no structured metadata. Syner reads for context, not data extraction
+- **Suggest, don't enforce** — skills recommend, you decide
+- **Execute with verification** — Action, Verify, Repeat
 
-When Syner reads a folder, it first looks for an `index.md` file. This file should explain:
-- What this folder is about
-- How notes in this folder are organized
-- Any special conventions or terminology used
-- How to interpret the content
+See [PHILOSOPHY.md](PHILOSOPHY.md) for the full rationale.
 
-This gives Syner the context it needs to understand your notes properly.
+## Notes
+
+Markdown is the language of agents. Create notes in `apps/notes/content/` with any structure you like.
+
+To give Syner context about a folder, add an `index.md`. See [note-conventions.md](skills/syner/note-conventions.md) for the full reading conventions.
 
 ## Skills
 
-### Orchestration
-
-- `/syner` - Main orchestrator that understands your context and delegates to specialized skills or agents
-
-### Knowledge
-
-- `/syner-load-all` - Load your full notes state
-- `/syner-track-idea` - Track idea evolution (proactive + manual)
-
-### Apps
-
-- `/create-syner-app` - Scaffold new applications with the standard stack (Next.js + TypeScript + Tailwind + shadcn)
-- `/update-syner-app` - Update existing apps to match current stack standards
-
-### Synthesis
-
-- `/syner-find-ideas` - Generate ideas from your knowledge
-- `/syner-find-links` - Find bridges between two different domains
-- `/syner-grow-note` - Promote a thought into a proper document
-
-### Backlog
-
-- `/backlog-triager` - Triage backlog items against current codebase state
-- `/backlog-reviewer` - Audit backlog health (stale items, duplicates, hidden TODOs)
-
-### Skills Meta
-
-- `/syner-enhance-skills` - Improve existing skills with best practices
+| Skill | What it does | Category |
+|-------|-------------|----------|
+| `/syner` | Orchestrator — understands context, routes to specialists or executes directly | Core |
+| `/syner-load-all` | Load your full notes state | Knowledge |
+| `/syner-track-idea` | Track idea evolution (proactive + manual) | Knowledge |
+| `/syner-find-ideas` | Generate ideas from your knowledge | Synthesis |
+| `/syner-find-links` | Find bridges between two different domains | Synthesis |
+| `/syner-grow-note` | Promote a thought into a proper document | Synthesis |
+| `/create-syner-app` | Scaffold new app with standard stack | Apps |
+| `/update-syner-app` | Update existing app to current standards | Apps |
+| `/backlog-triager` | Triage backlog items against codebase | Backlog |
+| `/backlog-reviewer` | Audit backlog health (stale, duplicates, hidden TODOs) | Backlog |
+| `/syner-enhance-skills` | Improve existing skills with best practices | Meta |
+| `/syner-researcher` | Research a topic from any source | Meta |
 
 ## Agents
 
 Agents handle complex execution with verification loops.
 
-- **code-reviewer** - Reviews code for quality, security, and best practices. Detects code type and applies specialized reviews (React/Next.js, UI/accessibility)
-- **syner-worker** - Executes tasks with verification using workflow patterns (chaining, parallelization, routing). Action → Verify → Repeat
+- **syner-worker** — Executes tasks using workflow patterns (chaining, parallelization, routing). Action, Verify, Repeat
+- **code-reviewer** — Reviews code for quality, security, and best practices

--- a/README.md
+++ b/README.md
@@ -7,25 +7,25 @@
 
 # Syner
 
-The open-source PKMS that reads your notes and helps you think, connect, and ship.
+A runtime for your personal knowledge — notes go in, thinking and action come out.
 
-Write markdown in `apps/notes/content/`. No schemas, no config. Then:
+## How it works
+
+Everything starts with your notes. Write markdown in `apps/notes/content/` — any structure, no schemas, no config. Your notes become the shared context that powers everything else.
+
+Skills read that context and do specific things with it: find ideas, connect domains, grow a thought into a full document. You invoke them directly or let the orchestrator route for you.
+
+Agents handle the heavy lifting. When a task needs multiple steps, they execute with verification loops — action, verify, repeat — until the job is done.
 
 ```
 /syner what should I work on next?
 ```
 
-## Features
-
-- **Knowledge as context** — your notes feed every skill, connections surface automatically
-- **Synthesis on demand** — generate ideas, find bridges between domains, grow scattered thoughts into documents
-- **Agentic execution** — tasks run with verification loops, not blind automation ([PHILOSOPHY.md](PHILOSOPHY.md))
-
 ## Skills
 
 | Skill | What it does |
 |-------|-------------|
-| `/syner` | Orchestrator — routes to specialists or executes directly |
+| `/syner` | Orchestrator — routes to the right skill or executes directly |
 | `/syner-load-all` | Load your full notes state |
 | `/syner-find-ideas` | Generate ideas from your knowledge |
 | `/syner-find-links` | Find bridges between two domains |

--- a/skills/syner-enhance-skills/SKILL.md
+++ b/skills/syner-enhance-skills/SKILL.md
@@ -83,7 +83,7 @@ ALWAYS use this structure:
 
 **Fix**: Use skill name or absolute pattern:
 ```markdown
-Execute `/state` skill (found via `Glob` pattern `skills/state/SKILL.md`)
+Execute `/syner-load-all` skill (found via `Glob` pattern `skills/syner-load-all/SKILL.md`)
 ```
 
 ### 7. Frontmatter Completeness
@@ -101,7 +101,7 @@ Example:
 context: fork
 agent: general-purpose
 skills:
-  - state
+  - syner-load-all
 ```
 
 ### 8. Philosophy Alignment
@@ -118,15 +118,14 @@ skills:
 
 **Problem**: Skill copy-pastes common patterns (e.g., "How to Read Notes" block).
 
-**Fix**: Reference conventions instead of duplicating:
+**Fix**: Reference the shared conventions file:
 ```markdown
-Follow note conventions from `apps/notes/content/index.md`:
-- Read `index.md` first in each folder for context
-- Use internal links, external docs (llms.txt), skill references (/skill-name)
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 ```
 
 **Known duplications** (22 lines repeated in 5 skills):
-- state, ideas, connect, graduate, trace
+- syner-load-all, syner-find-ideas, syner-find-links, syner-grow-note, syner-track-idea
 
 ### 10. Worker Delegation
 

--- a/skills/syner-find-ideas/SKILL.md
+++ b/skills/syner-find-ideas/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: ideas
+name: syner-find-ideas
 description: Generate startup ideas from your vault. Synthesize your unique knowledge, experiences, and observations into actionable startup or project ideas. Use when you want to explore what you could build based on your accumulated insights.
 metadata:
   author: syner
-  version: "1.0"
+  version: "1.1"
 ---
 
-# Ideas Skill
+# Syner Find Ideas
 
 ## Purpose
 
@@ -14,26 +14,8 @@ Generate startup and project ideas by mining the user's notes for unique insight
 
 ## How to Read Notes
 
-1. Find the project root (the directory containing `apps/`)
-2. Use `Glob` tool with pattern `apps/notes/content/**/*.md` to discover all markdown files
-3. **Important**: For each folder, check if an `index.md` exists and read it first - it provides context for interpreting that folder's contents
-4. Use `Read` tool to load file contents
-
-## Note Format Conventions
-
-### Internal Links
-Notes reference other notes using markdown links:
-- `[display text](./relative-path.md)` - Link to another note
-- Follow these links to understand relationships between notes
-
-### External Documentation Links
-Notes may reference external documentation, especially llms.txt endpoints:
-- `[tool](https://example.com/docs/llms.txt)` - LLM-friendly documentation
-- These indicate tools/technologies relevant to the note
-
-### Skill References
-Notes may reference skills using slash notation:
-- `/skill-name` - Indicates a workflow or tool to use in that context
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 
 ## Instructions
 
@@ -64,7 +46,7 @@ For each idea:
 ## Usage
 
 ```
-/ideas [optional: focus area or constraint]
+/syner-find-ideas [optional: focus area or constraint]
 ```
 
-Example: `/ideas developer-tools` or just `/ideas`
+Example: `/syner-find-ideas developer-tools` or just `/syner-find-ideas`

--- a/skills/syner-find-links/SKILL.md
+++ b/skills/syner-find-links/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: connect
+name: syner-find-links
 description: Bridge two domains you've been circling. Find unexpected connections between two different areas, topics, or projects in your notes. Use when you sense a link but can't articulate it, or to discover non-obvious relationships.
 metadata:
   author: syner
-  version: "1.0"
+  version: "1.1"
 ---
 
-# Connect Skill
+# Syner Find Links
 
 ## Purpose
 
@@ -14,26 +14,8 @@ Discover and articulate connections between two seemingly separate domains in th
 
 ## How to Read Notes
 
-1. Find the project root (the directory containing `apps/`)
-2. Use `Glob` tool with pattern `apps/notes/content/**/*.md` to discover all markdown files
-3. **Important**: For each folder, check if an `index.md` exists and read it first - it provides context for interpreting that folder's contents
-4. Use `Read` tool to load file contents
-
-## Note Format Conventions
-
-### Internal Links
-Notes reference other notes using markdown links:
-- `[display text](./relative-path.md)` - Link to another note
-- Follow these links to understand relationships between notes
-
-### External Documentation Links
-Notes may reference external documentation, especially llms.txt endpoints:
-- `[tool](https://example.com/docs/llms.txt)` - LLM-friendly documentation
-- These indicate tools/technologies relevant to the note
-
-### Skill References
-Notes may reference skills using slash notation:
-- `/skill-name` - Indicates a workflow or tool to use in that context
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 
 ## Instructions
 
@@ -64,7 +46,7 @@ Notes may reference skills using slash notation:
 ## Usage
 
 ```
-/connect [domain A] [domain B]
+/syner-find-links [domain A] [domain B]
 ```
 
-Example: `/connect meditation productivity-systems`
+Example: `/syner-find-links meditation productivity-systems`

--- a/skills/syner-grow-note/SKILL.md
+++ b/skills/syner-grow-note/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: graduate
+name: syner-grow-note
 description: Promote daily thoughts into real assets. Transform scattered daily notes, fleeting thoughts, and rough ideas into structured, actionable documents. Use when a thought has matured enough to become a proper article, plan, or reference document.
 metadata:
   author: syner
-  version: "1.0"
+  version: "1.1"
 ---
 
-# Graduate Skill
+# Syner Grow Note
 
 ## Purpose
 
@@ -14,26 +14,8 @@ Convert raw, daily thoughts into polished, structured documents that can be shar
 
 ## How to Read Notes
 
-1. Find the project root (the directory containing `apps/`)
-2. Use `Glob` tool with pattern `apps/notes/content/**/*.md` to discover all markdown files
-3. **Important**: For each folder, check if an `index.md` exists and read it first - it provides context for interpreting that folder's contents
-4. Use `Read` tool to load file contents
-
-## Note Format Conventions
-
-### Internal Links
-Notes reference other notes using markdown links:
-- `[display text](./relative-path.md)` - Link to another note
-- Follow these links to understand relationships between notes
-
-### External Documentation Links
-Notes may reference external documentation, especially llms.txt endpoints:
-- `[tool](https://example.com/docs/llms.txt)` - LLM-friendly documentation
-- These indicate tools/technologies relevant to the note
-
-### Skill References
-Notes may reference skills using slash notation:
-- `/skill-name` - Indicates a workflow or tool to use in that context
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 
 ## Instructions
 
@@ -65,7 +47,7 @@ Notes may reference skills using slash notation:
 ## Usage
 
 ```
-/graduate [note title or topic]
+/syner-grow-note [note title or topic]
 ```
 
-Example: `/graduate my thoughts on async communication`
+Example: `/syner-grow-note my thoughts on async communication`

--- a/skills/syner-load-all/SKILL.md
+++ b/skills/syner-load-all/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: state
+name: syner-load-all
 description: Load your full life + work state. Reads all notes in apps/notes/content/ and builds a unified context of your knowledge, projects, goals, and current thinking. Use when starting a new session or when you need the AI to understand your complete situation.
 metadata:
   author: syner
-  version: "1.0"
+  version: "1.1"
 ---
 
-# State Skill
+# Syner Load All
 
 ## Purpose
 
@@ -14,26 +14,8 @@ Build a comprehensive understanding of the user's current state by analyzing all
 
 ## How to Read Notes
 
-1. Find the project root (the directory containing `apps/`)
-2. Use `Glob` tool with pattern `apps/notes/content/**/*.md` to discover all markdown files
-3. **Important**: For each folder, check if an `index.md` exists and read it first - it provides context for interpreting that folder's contents
-4. Use `Read` tool to load file contents
-
-## Note Format Conventions
-
-### Internal Links
-Notes reference other notes using markdown links:
-- `[display text](./relative-path.md)` - Link to another note
-- Follow these links to understand relationships between notes
-
-### External Documentation Links
-Notes may reference external documentation, especially llms.txt endpoints:
-- `[tool](https://example.com/docs/llms.txt)` - LLM-friendly documentation
-- These indicate tools/technologies relevant to the note
-
-### Skill References
-Notes may reference skills using slash notation:
-- `/skill-name` - Indicates a workflow or tool to use in that context
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 
 ## Instructions
 

--- a/skills/syner-track-idea/SKILL.md
+++ b/skills/syner-track-idea/SKILL.md
@@ -17,9 +17,8 @@ Two modes:
 
 ## How to Read Notes
 
-Follow note conventions from `apps/notes/content/index.md`:
-- Read `index.md` first in each folder for context
-- Use internal links, external docs (llms.txt), skill references (/skill-name)
+Follow conventions in `skills/syner/note-conventions.md`.
+Use `Read` tool to load it before processing notes.
 
 Use `Bash` tool with `git log --oneline --follow -- [file]` to get commit history per file.
 

--- a/skills/syner/README.md
+++ b/skills/syner/README.md
@@ -9,7 +9,7 @@ Syner is the entry point when you don't know which skill to use. It reads your n
 ## What I Actually Do
 
 1. **Understand your intent** - I figure out what you're trying to accomplish
-2. **Load context proportionally** - None for greetings, targeted for single-project tasks, full `/state` only when needed
+2. **Load context proportionally** - None for greetings, targeted for single-project tasks, full `/syner-load-all` only when needed
 3. **Route or execute** - I either handle it myself (simple tasks) or delegate to the right skill/agent
 
 ## When to Use Me
@@ -36,10 +36,10 @@ I'm the **orchestrator**. Other skills are **specialists**.
 
 | Skill | What it does | When I route to it |
 |-------|--------------|-------------------|
-| `/state` | Builds context from notes | Preloaded automatically |
-| `/trace` | Tracks idea evolution | "How did X evolve?" |
-| `/connect` | Finds bridges between domains | "Connect X and Y" |
-| `/ideas` | Generates ideas from your knowledge | "What could I build?" |
+| `/syner-load-all` | Builds context from notes | Preloaded automatically |
+| `/syner-track-idea` | Tracks idea evolution | "How did X evolve?" |
+| `/syner-find-links` | Finds bridges between domains | "Connect X and Y" |
+| `/syner-find-ideas` | Generates ideas from your knowledge | "What could I build?" |
 | `/create-syner-app` | Scaffolds new apps | "Create an app" |
 | `/backlog-triager` | Triages backlog against code | "What's pending?" |
 
@@ -75,7 +75,7 @@ From `PHILOSOPHY.md`:
 ```
 /syner connect my ideas about AI agents with the backlog
 ```
-→ Loads full /state (multi-domain synthesis needed), then executes.
+→ Loads full /syner-load-all (multi-domain synthesis needed), then executes.
 
 ## What I'm Not
 

--- a/skills/syner/SKILL.md
+++ b/skills/syner/SKILL.md
@@ -34,7 +34,7 @@ Determine how much context this request needs:
 |-------|------|--------|
 | **None** | Casual conversation, greetings | Respond directly |
 | **Targeted** | Question about specific thing, single-project task | Use Glob/Grep/Read for that area |
-| **Full** | Multi-domain synthesis, needs complete picture | Call `Skill(skill="state")` |
+| **Full** | Multi-domain synthesis, needs complete picture | Call `Skill(skill="syner-load-all")` |
 
 ### How to Decide
 
@@ -67,9 +67,9 @@ From your notes, extract:
 | Skill | What it does |
 |-------|--------------|
 | `/syner-track-idea` | Track how an idea evolved over time |
-| `/connect` | Find bridges between two different domains |
-| `/ideas` | Generate ideas from your knowledge |
-| `/graduate` | Promote a thought into a proper document |
+| `/syner-find-links` | Find bridges between two different domains |
+| `/syner-find-ideas` | Generate ideas from your knowledge |
+| `/syner-grow-note` | Promote a thought into a proper document |
 | `/create-syner-app` | Scaffold a new application |
 | `/update-syner-app` | Update app to current stack |
 | `/backlog-triager` | Triage backlog against codebase |

--- a/skills/syner/note-conventions.md
+++ b/skills/syner/note-conventions.md
@@ -1,0 +1,26 @@
+# Note Conventions
+
+How to discover and read notes in the syner vault.
+
+## How to Read Notes
+
+1. Find the project root (the directory containing `apps/`)
+2. Use `Glob` tool with pattern `apps/notes/content/**/*.md` to discover all markdown files
+3. **Important**: For each folder, check if an `index.md` exists and read it first - it provides context for interpreting that folder's contents
+4. Use `Read` tool to load file contents
+
+## Note Format Conventions
+
+### Internal Links
+Notes reference other notes using markdown links:
+- `[display text](./relative-path.md)` - Link to another note
+- Follow these links to understand relationships between notes
+
+### External Documentation Links
+Notes may reference external documentation, especially llms.txt endpoints:
+- `[tool](https://example.com/docs/llms.txt)` - LLM-friendly documentation
+- These indicate tools/technologies relevant to the note
+
+### Skill References
+Notes may reference skills using slash notation:
+- `/skill-name` - Indicates a workflow or tool to use in that context


### PR DESCRIPTION
Rename ambiguous single-word skills to three-word syner-* names for clarity:
- state → syner-load-all
- ideas → syner-find-ideas
- connect → syner-find-links
- graduate → syner-grow-note

Extract shared "How to Read Notes" block (22 lines duplicated in 5 skills)
into skills/syner/note-conventions.md. All affected skills now reference
the shared file instead of duplicating the block.

Update all references across SKILL.md, README.md, and syner-enhance-skills.

https://claude.ai/code/session_012hozCx2QbRs8mbR13YczBK