### PR TITLE
fix(update-docs): replace find/ls bash commands with Glob calls (B1)

### DIFF
--- a/apps/dev/skills/update-docs/SKILL.md
+++ b/apps/dev/skills/update-docs/SKILL.md
@@ -1,3 +1,7 @@
+---
+tools: [Glob, Bash]
+---
+
 # update-docs
 
 Update documentation to reflect the current state of the codebase.
@@ -86,16 +90,11 @@ Parse arguments to determine what to update:
 
 ### 2. Scan the codebase
 
-```bash
-# Skills per app
-find apps/*/skills/*/SKILL.md
+Use `Glob` to discover files:
 
-# Agents
-find agents/*.md
-
-# Tools
-ls packages/vercel/src/tools/
-```
+- Skills per app: `Glob("apps/*/skills/*/SKILL.md")`
+- Agents: `Glob("agents/*.md")`
+- Tools: `Glob("packages/vercel/src/tools/*")`
 
 ### 3. For README.md updates
 


### PR DESCRIPTION
Replace raw bash `find`/`ls` commands in the "Scan the codebase" process step with named `Glob` tool calls. Add frontmatter declaring `tools: [Glob, Bash]` per B1 and D4 conventions.

Closes #223

Generated with [Claude Code](https://claude.ai/code)