### PR TITLE
chore(vercel): add TODO for external snapshot cache (Redis/KV)

### DIFF
--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -10,9 +10,9 @@ bun add @syner/vercel
 
 ```typescript
 // Create sandbox tools for an agent
-import { createAgentSandbox, createTools, stopSandbox } from '@syner/vercel'
+import { createSandbox, createTools, stopSandbox } from '@syner/vercel'
 
-const { sandbox, workdir } = await createAgentSandbox({
+const { sandbox, workdir } = await createSandbox({
   repoUrl: 'https://github.com/synerops/syner',
 })
 const tools = createTools(sandbox)
@@ -56,9 +56,9 @@ import { Bash, Fetch } from '@syner/vercel'
 ### Shared sandbox (recommended for multi-call workflows)
 
 ```typescript
-import { createAgentSandbox, createTools, stopSandbox } from '@syner/vercel'
+import { createSandbox, createTools, stopSandbox } from '@syner/vercel'
 
-const { sandbox } = await createAgentSandbox({ repoUrl })
+const { sandbox } = await createSandbox({ repoUrl })
 const tools = createTools(sandbox)  // all 7 tools share one sandbox
 // Or pick specific tools: createToolsByName(sandbox, ['Bash', 'Read'])
 

--- a/packages/vercel/src/runtime/index.ts
+++ b/packages/vercel/src/runtime/index.ts
@@ -222,6 +222,7 @@ export function createRuntime(config?: RuntimeConfig): Runtime {
     const { model, fallbacks, modelId } = resolveModel(tier)
 
     // 2. Lazy sandbox (created on first tool use, shared per generate call)
+    //    Uses snapshot caching: first call clones + snapshots, subsequent calls restore instantly.
     let sandbox: AgentSandbox | null = null
     let initPromise: Promise<AgentSandbox> | null = null
 
@@ -230,11 +231,10 @@ export function createRuntime(config?: RuntimeConfig): Runtime {
       if (initPromise) return initPromise
       initPromise = (async () => {
         try {
-          await onStatus('Cloning repository...')
+          await onStatus('Preparing sandbox...')
           const result = await createAgentSandbox({
             repoUrl: DEFAULT_REPO_URL,
             branch: DEFAULT_BRANCH,
-            workdir: 'workspace',
             timeout: 300000,
           })
           sandbox = result.sandbox

--- a/packages/vercel/src/runtime/index.ts
+++ b/packages/vercel/src/runtime/index.ts
@@ -19,7 +19,7 @@ import { SkillLoader, SkillsMap, type SkillDescriptor } from '../skills'
 import { createSkillTool, createPrepareStep, preprocessPrompt } from '../tools/skill'
 import { createTaskTool } from '../tools/task'
 import { VercelRunAdapter } from './adapter'
-import { createAgentSandbox, stopSandbox, type AgentSandbox } from './sandbox'
+import { createSandbox, stopSandbox, type SandboxInstance } from './sandbox'
 import {
   bashInputSchema,
   fetchInputSchema,
@@ -65,7 +65,7 @@ export interface GenerateOptions {
 export interface ToolDef {
   description: string
   inputSchema: unknown
-  executeWithSandbox: (sandbox: AgentSandbox, input: never) => Promise<unknown>
+  executeWithSandbox: (sandbox: SandboxInstance, input: never) => Promise<unknown>
 }
 
 export interface AgentCardOutput {
@@ -223,16 +223,16 @@ export function createRuntime(config?: RuntimeConfig): Runtime {
 
     // 2. Lazy sandbox (created on first tool use, shared per generate call)
     //    Uses snapshot caching: first call clones + snapshots, subsequent calls restore instantly.
-    let sandbox: AgentSandbox | null = null
-    let initPromise: Promise<AgentSandbox> | null = null
+    let sandbox: SandboxInstance | null = null
+    let initPromise: Promise<SandboxInstance> | null = null
 
-    async function ensureSandbox(): Promise<AgentSandbox> {
+    async function ensureSandbox(): Promise<SandboxInstance> {
       if (sandbox) return sandbox
       if (initPromise) return initPromise
       initPromise = (async () => {
         try {
           await onStatus('Preparing sandbox...')
-          const result = await createAgentSandbox({
+          const result = await createSandbox({
             repoUrl: DEFAULT_REPO_URL,
             branch: DEFAULT_BRANCH,
             timeout: 300000,

--- a/packages/vercel/src/runtime/index.ts
+++ b/packages/vercel/src/runtime/index.ts
@@ -19,7 +19,7 @@ import { SkillLoader, SkillsMap, type SkillDescriptor } from '../skills'
 import { createSkillTool, createPrepareStep, preprocessPrompt } from '../tools/skill'
 import { createTaskTool } from '../tools/task'
 import { VercelRunAdapter } from './adapter'
-import { createSandbox, stopSandbox, type SandboxInstance } from './sandbox'
+import { createSandbox, stopSandbox, type Sandbox } from './sandbox'
 import {
   bashInputSchema,
   fetchInputSchema,
@@ -65,7 +65,7 @@ export interface GenerateOptions {
 export interface ToolDef {
   description: string
   inputSchema: unknown
-  executeWithSandbox: (sandbox: SandboxInstance, input: never) => Promise<unknown>
+  executeWithSandbox: (sandbox: Sandbox, input: never) => Promise<unknown>
 }
 
 export interface AgentCardOutput {
@@ -223,10 +223,10 @@ export function createRuntime(config?: RuntimeConfig): Runtime {
 
     // 2. Lazy sandbox (created on first tool use, shared per generate call)
     //    Uses snapshot caching: first call clones + snapshots, subsequent calls restore instantly.
-    let sandbox: SandboxInstance | null = null
-    let initPromise: Promise<SandboxInstance> | null = null
+    let sandbox: Sandbox | null = null
+    let initPromise: Promise<Sandbox> | null = null
 
-    async function ensureSandbox(): Promise<SandboxInstance> {
+    async function ensureSandbox(): Promise<Sandbox> {
       if (sandbox) return sandbox
       if (initPromise) return initPromise
       initPromise = (async () => {

--- a/packages/vercel/src/runtime/sandbox.ts
+++ b/packages/vercel/src/runtime/sandbox.ts
@@ -1,6 +1,6 @@
 import { Sandbox, Snapshot } from '@vercel/sandbox'
+export type { Sandbox }
 
-export type SandboxInstance = Sandbox
 
 export interface SandboxConfig {
   repoUrl: string
@@ -39,7 +39,7 @@ async function validateSnapshot(snapshotId: string): Promise<string | null> {
  * Create a sandbox from scratch: clone repo and take a snapshot for future reuse.
  * The source sandbox is stopped by snapshot(), so we create a second one from the snapshot.
  */
-async function createAndSnapshot(config: SandboxConfig & { key: string }): Promise<{ sandbox: SandboxInstance; workdir: string }> {
+async function createAndSnapshot(config: SandboxConfig & { key: string }): Promise<{ sandbox: Sandbox; workdir: string }> {
   const {
     repoUrl,
     branch = 'main',
@@ -95,7 +95,7 @@ async function createFromSnapshot(
   snapshotId: string,
   config: Pick<SandboxConfig, 'timeout' | 'env'>,
   workdir: string,
-): Promise<{ sandbox: SandboxInstance; workdir: string }> {
+): Promise<{ sandbox: Sandbox; workdir: string }> {
   console.log(`[Sandbox] Warm start: creating from snapshot ${snapshotId}...`)
 
   const sandbox = await Sandbox.create({
@@ -116,7 +116,7 @@ async function createFromSnapshot(
  * - First call: creates sandbox with git source, snapshots it, then creates from snapshot
  * - Subsequent calls: creates directly from cached snapshot (milliseconds)
  */
-export async function createSandbox(config: SandboxConfig): Promise<{ sandbox: SandboxInstance; workdir: string }> {
+export async function createSandbox(config: SandboxConfig): Promise<{ sandbox: Sandbox; workdir: string }> {
   const {
     repoUrl,
     branch = 'main',
@@ -145,7 +145,7 @@ export async function createSandbox(config: SandboxConfig): Promise<{ sandbox: S
 /**
  * Stop and cleanup a sandbox
  */
-export async function stopSandbox(sandbox: SandboxInstance): Promise<void> {
+export async function stopSandbox(sandbox: Sandbox): Promise<void> {
   console.log(`[Sandbox] Stopping sandbox...`)
   await sandbox.stop()
   console.log(`[Sandbox] Sandbox stopped`)

--- a/packages/vercel/src/runtime/sandbox.ts
+++ b/packages/vercel/src/runtime/sandbox.ts
@@ -1,57 +1,141 @@
-import { Sandbox } from '@vercel/sandbox'
+import { Sandbox, Snapshot } from '@vercel/sandbox'
 
 export type AgentSandbox = Sandbox
 
 export interface SandboxConfig {
   repoUrl: string
   branch?: string
-  workdir?: string
   timeout?: number
   /** Environment variables injected into the sandbox */
   env?: Record<string, string>
 }
 
+// In-memory snapshot cache keyed by "repoUrl#branch"
+const snapshotCache = new Map<string, string>()
+
+function cacheKey(repoUrl: string, branch: string): string {
+  return `${repoUrl}#${branch}`
+}
+
 /**
- * Create a sandbox with the repository cloned
- * This sandbox can be reused across multiple tool calls
+ * Validate that a cached snapshot still exists and is usable.
+ * Returns the snapshotId if valid, null otherwise.
+ */
+async function validateSnapshot(snapshotId: string): Promise<string | null> {
+  try {
+    const snap = await Snapshot.get({ snapshotId })
+    if (snap.status === 'created') return snapshotId
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Create a sandbox from scratch: clone repo and take a snapshot for future reuse.
+ * The source sandbox is stopped by snapshot(), so we create a second one from the snapshot.
+ */
+async function createAndSnapshot(config: SandboxConfig & { key: string }): Promise<{ sandbox: AgentSandbox; workdir: string }> {
+  const {
+    repoUrl,
+    branch = 'main',
+    timeout = 300000,
+    env,
+    key,
+  } = config
+
+  console.log(`[Sandbox] Cold start: creating sandbox with git source...`)
+
+  // 1. Create sandbox with repo already cloned via source
+  const setupSandbox = await Sandbox.create({
+    source: { url: repoUrl, type: 'git' },
+    runtime: 'node24',
+    timeout,
+    env,
+  })
+
+  // 2. Discover the working directory
+  const homeResult = await setupSandbox.runCommand('sh', ['-c', 'echo $HOME'])
+  const home = (await homeResult.stdout()).trim() || '/root'
+
+  // Find where the repo was cloned (Vercel typically uses /vercel/sandbox or $HOME)
+  const findResult = await setupSandbox.runCommand('sh', ['-c', 'ls -d /vercel/sandbox 2>/dev/null || echo $HOME'])
+  const workdir = (await findResult.stdout()).trim() || home
+
+  console.log(`[Sandbox] Repo cloned, workdir: ${workdir}`)
+  console.log(`[Sandbox] Taking snapshot for future reuse...`)
+
+  // 3. Snapshot (this stops setupSandbox automatically)
+  const snapshot = await setupSandbox.snapshot()
+  const snapshotId = snapshot.snapshotId
+  snapshotCache.set(key, snapshotId)
+
+  console.log(`[Sandbox] Snapshot created: ${snapshotId}`)
+
+  // 4. Create a fresh sandbox from the snapshot (instant)
+  const sandbox = await Sandbox.create({
+    source: { type: 'snapshot', snapshotId },
+    runtime: 'node24',
+    timeout,
+    env,
+  })
+
+  console.log(`[Sandbox] Sandbox ready from snapshot`)
+  return { sandbox, workdir }
+}
+
+/**
+ * Create a sandbox from an existing snapshot (warm path).
+ */
+async function createFromSnapshot(
+  snapshotId: string,
+  config: Pick<SandboxConfig, 'timeout' | 'env'>,
+  workdir: string,
+): Promise<{ sandbox: AgentSandbox; workdir: string }> {
+  console.log(`[Sandbox] Warm start: creating from snapshot ${snapshotId}...`)
+
+  const sandbox = await Sandbox.create({
+    source: { type: 'snapshot', snapshotId },
+    runtime: 'node24',
+    timeout: config.timeout ?? 300000,
+    env: config.env,
+  })
+
+  console.log(`[Sandbox] Sandbox ready from snapshot (warm)`)
+  return { sandbox, workdir }
+}
+
+/**
+ * Create a sandbox with the repository ready.
+ *
+ * Uses snapshots to avoid re-cloning on every call:
+ * - First call: creates sandbox with git source, snapshots it, then creates from snapshot
+ * - Subsequent calls: creates directly from cached snapshot (milliseconds)
  */
 export async function createAgentSandbox(config: SandboxConfig): Promise<{ sandbox: AgentSandbox; workdir: string }> {
   const {
     repoUrl,
     branch = 'main',
-    workdir = 'workspace', // relative to home
-    timeout = 300000, // 5 minutes
-    env,
   } = config
 
-  console.log(`[Sandbox] Creating sandbox...`)
-  const sandbox = await Sandbox.create({ runtime: 'node24', timeout, env })
+  const key = cacheKey(repoUrl, branch)
 
-  // Get home directory
-  const homeResult = await sandbox.runCommand('sh', ['-c', 'echo $HOME'])
-  const home = (await homeResult.stdout()).trim() || '/root'
-  const fullWorkdir = `${home}/${workdir}`
-
-  console.log(`[Sandbox] Home: ${home}, Workdir: ${fullWorkdir}`)
-  console.log(`[Sandbox] Cloning ${repoUrl} (branch: ${branch})...`)
-
-  const cloneResult = await sandbox.runCommand('git', [
-    'clone',
-    '--depth', '1',
-    '--branch', branch,
-    repoUrl,
-    fullWorkdir
-  ])
-
-  if (cloneResult.exitCode !== 0) {
-    const stderr = await cloneResult.stderr()
-    await sandbox.stop()
-    throw new Error(`Failed to clone repo: ${stderr}`)
+  // Try cached snapshot first
+  const cachedSnapshotId = snapshotCache.get(key)
+  if (cachedSnapshotId) {
+    const validId = await validateSnapshot(cachedSnapshotId)
+    if (validId) {
+      // Warm path — we need to know the workdir from previous creation
+      // Since snapshots preserve the filesystem, the workdir is the same
+      return createFromSnapshot(validId, config, '/vercel/sandbox')
+    }
+    // Snapshot expired or deleted, remove from cache
+    snapshotCache.delete(key)
+    console.log(`[Sandbox] Cached snapshot expired, creating fresh...`)
   }
 
-  console.log(`[Sandbox] Repository cloned to ${fullWorkdir}`)
-
-  return { sandbox, workdir: fullWorkdir }
+  // Cold path — create, clone, snapshot
+  return createAndSnapshot({ ...config, key })
 }
 
 /**

--- a/packages/vercel/src/runtime/sandbox.ts
+++ b/packages/vercel/src/runtime/sandbox.ts
@@ -11,6 +11,10 @@ export interface SandboxConfig {
 }
 
 // In-memory snapshot cache keyed by "repoUrl#branch"
+// TODO: Replace with external cache (Redis/Vercel KV) so snapshot IDs survive
+// across serverless invocations. The snapshot itself persists on Vercel's side,
+// but the ID is lost when the function instance is recycled.
+// See: https://github.com/synerops/syner — search for "snapshot cache" in backlog.
 const snapshotCache = new Map<string, string>()
 
 function cacheKey(repoUrl: string, branch: string): string {

--- a/packages/vercel/src/runtime/sandbox.ts
+++ b/packages/vercel/src/runtime/sandbox.ts
@@ -1,6 +1,6 @@
 import { Sandbox, Snapshot } from '@vercel/sandbox'
 
-export type AgentSandbox = Sandbox
+export type SandboxInstance = Sandbox
 
 export interface SandboxConfig {
   repoUrl: string
@@ -35,7 +35,7 @@ async function validateSnapshot(snapshotId: string): Promise<string | null> {
  * Create a sandbox from scratch: clone repo and take a snapshot for future reuse.
  * The source sandbox is stopped by snapshot(), so we create a second one from the snapshot.
  */
-async function createAndSnapshot(config: SandboxConfig & { key: string }): Promise<{ sandbox: AgentSandbox; workdir: string }> {
+async function createAndSnapshot(config: SandboxConfig & { key: string }): Promise<{ sandbox: SandboxInstance; workdir: string }> {
   const {
     repoUrl,
     branch = 'main',
@@ -91,7 +91,7 @@ async function createFromSnapshot(
   snapshotId: string,
   config: Pick<SandboxConfig, 'timeout' | 'env'>,
   workdir: string,
-): Promise<{ sandbox: AgentSandbox; workdir: string }> {
+): Promise<{ sandbox: SandboxInstance; workdir: string }> {
   console.log(`[Sandbox] Warm start: creating from snapshot ${snapshotId}...`)
 
   const sandbox = await Sandbox.create({
@@ -112,7 +112,7 @@ async function createFromSnapshot(
  * - First call: creates sandbox with git source, snapshots it, then creates from snapshot
  * - Subsequent calls: creates directly from cached snapshot (milliseconds)
  */
-export async function createAgentSandbox(config: SandboxConfig): Promise<{ sandbox: AgentSandbox; workdir: string }> {
+export async function createSandbox(config: SandboxConfig): Promise<{ sandbox: SandboxInstance; workdir: string }> {
   const {
     repoUrl,
     branch = 'main',
@@ -141,7 +141,7 @@ export async function createAgentSandbox(config: SandboxConfig): Promise<{ sandb
 /**
  * Stop and cleanup a sandbox
  */
-export async function stopSandbox(sandbox: AgentSandbox): Promise<void> {
+export async function stopSandbox(sandbox: SandboxInstance): Promise<void> {
   console.log(`[Sandbox] Stopping sandbox...`)
   await sandbox.stop()
   console.log(`[Sandbox] Sandbox stopped`)


### PR DESCRIPTION
<p>
  <picture>
    <source srcset="https://github.com/user-attachments/assets/70cee063-9701-479d-a61e-f1da868c0957" media="(prefers-color-scheme: dark)">
    <img src="https://github.com/user-attachments/assets/4859e8b3-58ab-4649-bf39-a2fb1b7ea6b7" alt="Syner" height="40"/>
  </picture>
  <br/>
  <strong>syner/{agent-name}</strong>
</p>

---

| | |
|---|---|
| **Closes** | #{issue-number} |
| **Agent** | `{agent-name}` |
| **Scope** | `{package-or-app}` |
| **Model** | `opus` · `sonnet` |

### Capabilities

<!-- What can this agent do? Organized by module or responsibility. -->

-

### When to invoke

<!-- Concrete scenarios where the orchestrator should route to this agent -->

-

### What changed

<!-- Files added or modified -->

-

### Test plan

- [ ] Agent identifies itself correctly
- [ ] Capabilities match actual source code
- [ ] No workflow/worktree prescriptions (orchestrator's job)
- [ ] Symlink created in `.claude/agents/`

---

<sub>syner/{author}</sub>