### PR TITLE
fix: review plan logic

### DIFF
--- a/apps/dev/skills/review-plan/SKILL.md
+++ b/apps/dev/skills/review-plan/SKILL.md
@@ -95,6 +95,7 @@ If a plan has NO existing decisions, this is a fresh review — use the full rev
 
 6. **Wait for the verdict.** The user decides one of:
    - **Approved** — plan is good, add frontmatter `status: approved`
+   - **Refining** — plan needs active clarification and iteration, add frontmatter `status: refining`
    - **Refactor** — plan needs changes, discuss what and why, then edit
    - **Defer** — plan is valid but not needed yet, leave as draft
 

--- a/apps/dev/skills/review-plan/scripts/scan-plans.ts
+++ b/apps/dev/skills/review-plan/scripts/scan-plans.ts
@@ -389,6 +389,7 @@ const summary = {
   total: allPlans.length,
   byStatus: {
     draft: allPlans.filter(p => p.status === "draft").length,
+    refining: allPlans.filter(p => p.status === "refining").length,
     approved: allPlans.filter(p => p.status === "approved").length,
     "in-progress": allPlans.filter(p => p.status === "in-progress").length,
     review: allPlans.filter(p => p.status === "review").length,

--- a/skills/syner/scripts/plans/scan.ts
+++ b/skills/syner/scripts/plans/scan.ts
@@ -389,6 +389,7 @@ const summary = {
   total: allPlans.length,
   byStatus: {
     draft: allPlans.filter(p => p.status === "draft").length,
+    refining: allPlans.filter(p => p.status === "refining").length,
     approved: allPlans.filter(p => p.status === "approved").length,
     "in-progress": allPlans.filter(p => p.status === "in-progress").length,
     review: allPlans.filter(p => p.status === "review").length,


### PR DESCRIPTION
This pull request adds support for a new "refining" status to the review plan workflow and updates related scripts to recognize and count plans with this status. This will help better track plans that are actively being clarified or iterated on.

**Workflow documentation update:**

* Added "Refining" as a possible status in the review plan process, indicating that a plan needs active clarification and iteration, and specifying to add `status: refining` in the frontmatter.

**Script updates for plan status tracking:**

* Updated `apps/dev/skills/review-plan/scripts/scan-plans.ts` to count and report plans with the new "refining" status in the summary statistics.
* Updated `skills/syner/scripts/plans/scan.ts` to include the "refining" status in its plan status summary.