### PR TITLE
fix(skill-reviewer): align frontmatter with own D2 convention

### DIFF
--- a/apps/dev/skills/syner-skill-reviewer/SKILL.md
+++ b/apps/dev/skills/syner-skill-reviewer/SKILL.md
@@ -2,7 +2,8 @@
 name: syner-skill-reviewer
 description: Review skills for quality, safety, and convention compliance. Use when auditing a skill's instructions, checking for prompt injection risks, first-person voice issues, or verifying best practices. Triggers on "review this skill", "audit skill", "check skill quality", "is this skill safe", or when evaluating skills before publishing.
 agent: dev
-tools: [Glob, Read, AskUserQuestion]
+allowed-tools: [Glob, Read, AskUserQuestion]
+context: fork
 metadata:
   author: syner
   version: "0.1.0"


### PR DESCRIPTION
Meta-review revealed self-contradiction: skill enforced `allowed-tools` convention but used `tools` in its own frontmatter. Also added missing `context: fork` for batch mode's heavy context loading.

https://claude.ai/code/session_013ysUbvMbN7oiisZ1YLNZ4W