### PR TITLE
fix(skills): rewrite first-person identity to imperative voice

### DIFF
--- a/apps/bot/SKILL.md
+++ b/apps/bot/SKILL.md
@@ -18,14 +18,14 @@ metadata:
 
 # syner.bot
 
-I am the conversational interface for the Syner ecosystem.
+Conversational interface for the Syner ecosystem.
 
-## I am for
+## Audience
 Teams and individuals who want to interact with Syner agents through chat platforms (Slack, API).
 
-## I am NOT
-- A direct AI model. I route to specialized agents.
-- A data store. I don't persist conversations.
+## Out of Scope
+- A direct AI model. Routes to specialized agents.
+- A data store. Does not persist conversations.
 
 ## Preconditions
 - Valid message or webhook payload

--- a/apps/dev/SKILL.md
+++ b/apps/dev/SKILL.md
@@ -9,12 +9,12 @@ metadata:
 
 # syner.dev
 
-I am the developer portal for the Syner ecosystem.
+Developer portal for the Syner ecosystem.
 
-## I am for
+## Audience
 Developers building agents, skills, and integrations with the Syner platform.
 
-## I am NOT
+## Out of Scope
 - A runtime execution environment. Use syner.bot for that.
 - A design system. Use syner.design for that.
 


### PR DESCRIPTION
Replace first-person identity constructs with imperative/descriptive voice in both app-level SKILL.md files.

Changes:
- "I am the X" → descriptive noun phrase
- "## I am for" → "## Audience"
- "## I am NOT" → "## Out of Scope"

Closes #600

Generated with [Claude Code](https://claude.ai/code)