### PR TITLE
feat(skills): add "Think, Don't Template" pattern

### DIFF
--- a/apps/dev/skills/create-syner-skill/SKILL.md
+++ b/apps/dev/skills/create-syner-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-syner-skill
-description: Create syner skills. Use when creating new skills, or when user says "crear skill", "new skill", "add capability".
+description: Create skills for the syner ecosystem. Scaffolds the file, sets up symlinks, and iterates until the skill works when invoked.
 metadata:
   author: syner
   version: "0.1.0"
@@ -27,6 +27,18 @@ Get expected output FIRST, then compare actual vs expected.
 
 ### 3. Verify Output == Instructions
 When testing, check that the skill's actual behavior matches what the instructions say it should do. Discrepancies = bugs.
+
+### 4. Think, Don't Template
+Skills should describe **how to think**, not what fields to fill. A skill with fixed headers and bullet counts produces generic output regardless of context.
+
+The evolution (learned from save-bookmark):
+- **v1 (template):** Fixed structure, field extraction, regex triggers → output reads like a form
+- **v2 (template + context):** Same structure but with project references injected → still a form, just with better fill
+- **v3 (thinking process):** No fixed structure — skill describes questions to ask, connections to make, decisions to weigh → output matches what the content actually needs
+
+**The test:** If you swap the input and the body still makes sense, the skill wrote a template. If you remove the user's context and the body still reads fine, the skill didn't personalize. Both mean: rewrite the skill instructions.
+
+When scaffolding: prefer "## How to Think" over "## Output" with a fixed format. The output section should describe *qualities* (honest, connected to context, specific) not *structure* (3-5 bullets, H2 for Why, H2 for Takeaways).
 
 ## Critical Concept
 
@@ -81,65 +93,47 @@ Ask only if unclear: "Is this skill specific to an app or shared?"
 
 ### 3. Scaffold
 
-```markdown
+The frontmatter is fixed. Everything below it depends on what the skill needs.
+
+```yaml
 ---
 name: {name}
-description: {description}. Use when {triggers}.
+description: {what it does — in terms of value, not trigger phrases}
 metadata:
   author: syner
   version: "0.0.1"
-  agent: dev
+  agent: {app}
 allowed-tools:
-  - Read
-  - Glob
-  - Write
-  - Bash
+  - {tools the skill actually uses}
 ---
-
-# {Name}
-
-{Purpose - one line}
-
-## Process
-
-{Step by step instructions - imperative voice}
-
-### 1. {First Step}
-
-{Details}
-
-### 2. {Second Step}
-
-{Details}
-
-## Output
-
-{Exact format - be specific}
-
-## Testing
-
-To test this skill:
-1. {test case}
-
-Cleanup: {cleanup commands if needed}
-
-## Boundaries
-
-Validate against `/syner-boundaries`:
-- {relevant boundary}
-- {relevant boundary}
 ```
 
-### 4. Description Triggers
+Below the frontmatter, write what the skill needs. Some skills need step-by-step processes. Others need a thinking framework. Don't default to numbered steps if the skill is about judgment.
 
-The `description` field determines when the skill auto-triggers. Include:
-- What it does
-- Keywords that should trigger it
-- Natural phrases users might say
+**Always include:**
+- How the skill thinks (process or thinking framework)
+- Testing section (how to verify it works)
+- Boundaries (constraints)
+
+**Include only if the skill needs it:**
+- Output format (only if structure matters — e.g., a report, a file with frontmatter)
+- Edge cases (only if non-obvious)
+
+**Avoid:**
+- Fixed output templates with placeholder fields — these produce form-fill output
+- Numbered bullet counts ("3-5 bullets") — let content decide length
+- Headers that become mandatory structure ("## Why", "## Key Ideas") — the skill will fill them even when they add nothing
+
+### 4. Description
+
+The `description` field explains what the skill does and when it's useful. Write it as a sentence a human would say, not a list of trigger phrases.
 
 ```yaml
-# Good - specific triggers
-description: Create syner skills. Use when user says "crear skill", "new skill", "add capability".
+# Good - describes value and context
+description: Save a URL as a markdown bookmark that connects to what you're building and thinking about.
+
+# Bad - regex trigger list
+description: Save URLs. Use when "save bookmark", "guardar link", "bookmark this", "save this url".
 
 # Bad - vague
 description: Creates skills.
@@ -218,11 +212,13 @@ Normal flow:
 | Anti-Pattern | Fix |
 |--------------|-----|
 | First-person voice ("I will...") | Imperative ("Analyze the...") |
-| Vague description | Add trigger phrases |
+| Description as regex trigger list | Describe value in a human sentence |
+| Fixed output template with placeholders | Describe output qualities, not structure |
+| Numbered bullet counts ("3-5 bullets") | Let content decide length |
 | "ONLY return X" but returns extra | Add "No explanation, no commentary" |
 | Tools used but not declared | Add to frontmatter |
 | No testing section | Add test cases |
-| Headings like "What I Do" | Use "Process" or "Capabilities" |
+| Headings like "What I Do" | Use "Process" or "How to Think" |
 
 ## Performance: Parallel Tool Calls
 

--- a/apps/dev/skills/syner-enhance-skills/SKILL.md
+++ b/apps/dev/skills/syner-enhance-skills/SKILL.md
@@ -61,8 +61,9 @@ For each finding, determine the concrete change:
 | Path resolution (B2) | Anchor to project root |
 | Skill references (B3) | Use `/skill-name` format |
 | Missing input handling (B4) | Add default or AskUserQuestion |
-| Output structure (B5) | Add explicit template |
-| Missing delegation (B6) | Add subagent delegation |
+| Output structure (B5) | Describe output qualities, remove rigid placeholder templates |
+| Description quality (B6) | Replace trigger lists with value-describing sentences |
+| Missing delegation (B7) | Add execution contract for multi-step operations |
 
 ## Step 4: Confirm Changes
 

--- a/apps/dev/skills/syner-skill-reviewer/SKILL.md
+++ b/apps/dev/skills/syner-skill-reviewer/SKILL.md
@@ -119,10 +119,12 @@ Exception: skills that produce structured artifacts with a contract (frontmatter
 
 The `description` field should explain what the skill does and when it's useful — as a human sentence.
 
-Red flags:
+Red flags — trigger phrases that **replace** the value sentence:
 - **Regex trigger lists**: `Use when "crear pr", "create pr", "abrir pr"` — these are pattern-matching strings, not descriptions
 - **"Use when user says..."**: The description should describe value, not list activation phrases
 - **"Triggers on..."**: Same problem — keyword lists instead of meaning
+
+Acceptable: trigger phrases that **supplement** a clear value sentence. A description like "Create GitHub PRs using templates. Use when creating or submitting pull requests." is fine — the first sentence carries the value, the second adds discoverability.
 
 Good: "Save a URL as a markdown bookmark that connects to what you're building and thinking about."
 Bad: `Save URLs. Use when "save bookmark", "guardar link", "bookmark this".`

--- a/apps/dev/skills/syner-skill-reviewer/SKILL.md
+++ b/apps/dev/skills/syner-skill-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: syner-skill-reviewer
-description: Review skills for quality, safety, and convention compliance. Use when auditing a skill's instructions, checking for prompt injection risks, first-person voice issues, or verifying best practices. Triggers on "review this skill", "audit skill", "check skill quality", "is this skill safe", or when evaluating skills before publishing.
+description: Review skills for quality, safety, and convention compliance. Dev's quality gate before skills go live — checks voice, injection risks, technical patterns, and ecosystem consistency.
 agent: dev
 allowed-tools: [Glob, Read, AskUserQuestion]
 context: fork
@@ -111,9 +111,23 @@ When a skill needs input but doesn't get any, it should either have a sensible d
 
 ### B5. Output Structure
 
-If a skill's output format is important (and it usually is for skills that produce reports or structured artifacts), define it with an explicit template. Vague descriptions like "output a summary" lead to inconsistent results across invocations.
+If a skill's output needs specific qualities (honest, contextual, actionable), describe those qualities. Avoid fixed templates with placeholder fields (`{3-5 bullets}`, `## Why`, `## Key Ideas`) — they produce form-fill output regardless of context. The model fills every field even when the content doesn't warrant it.
 
-### B6. Delegation
+Exception: skills that produce structured artifacts with a contract (frontmatter schemas, reports with defined sections) do need explicit structure. The distinction: is the structure serving the consumer, or just making the skill easier to write?
+
+### B6. Description Quality
+
+The `description` field should explain what the skill does and when it's useful — as a human sentence.
+
+Red flags:
+- **Regex trigger lists**: `Use when "crear pr", "create pr", "abrir pr"` — these are pattern-matching strings, not descriptions
+- **"Use when user says..."**: The description should describe value, not list activation phrases
+- **"Triggers on..."**: Same problem — keyword lists instead of meaning
+
+Good: "Save a URL as a markdown bookmark that connects to what you're building and thinking about."
+Bad: `Save URLs. Use when "save bookmark", "guardar link", "bookmark this".`
+
+### B7. Delegation
 
 When a skill involves multiple file changes, verification loops, or iterative refinement, it should use Syner's execution contract (gather context → take action → verify → iterate) rather than handling the complexity inline without structure. A skill that tries to do everything without verification tends to get long and brittle.
 


### PR DESCRIPTION
## Summary

- Add "Think, Don't Template" as Core Principle #4 in `create-syner-skill` — documents the v1→v3 evolution learned from save-bookmark
- Add B5 (Output Structure) and B6 (Description Quality) checks to `syner-skill-reviewer` — flags fixed templates and regex trigger lists
- Fix both skills' own descriptions to follow their own advice

## Context

During save-bookmark creation, we iterated through three versions:
- v1: fixed template, regex triggers → form-fill output
- v2: same template + context injected → better fill, still a form
- v3: thinking process, no template → output matches what content needs

This pattern should prevent future skills from starting at v1.

## Changes

**create-syner-skill:**
- New Core Principle #4: Think, Don't Template (with tests for quality)
- Scaffold section: no longer prescribes fixed headers
- Description guidance: human sentences, not regex lists
- 3 new anti-patterns (regex triggers, placeholder templates, bullet counts)

**syner-skill-reviewer:**
- B5: flag fixed output templates with placeholder fields
- B6: flag regex trigger lists in descriptions
- 10 existing skills will get flagged on next batch review

## Test plan

- [ ] Run `/syner-skill-reviewer` in batch — verify B6 flags the 10 skills with regex descriptions
- [ ] Create a new skill with `/create-syner-skill` — verify scaffold guidance no longer prescribes fixed headers

https://claude.ai/code/session_01Y2sm2YsjqyKPKHGXqZsshV