### PR TITLE
feat(syner): add bookmarks to context loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,10 @@ Content is rendered via [Fumadocs](https://fumadocs.dev) headless — `source.co
 | Scope | When | Pattern |
 |-------|------|---------|
 | None | Casual conversation | Respond directly |
-| Project | Syner-level context | `.syner/vaults/**/*.md` + relevant `.syner/bookmarks/*.md` |
+| Project | Syner-level context | `.syner/vaults/**/*.md` |
 | App | Task within one app | `.syner/vaults/{app}/**/*.md` |
-| Targeted | Specific file/topic | Glob/Grep for that area. Check bookmarks if topic matches. |
-| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` + `.syner/bookmarks/*.md` via `/load-all` |
+| Targeted | Specific file/topic | Glob/Grep for that area |
+| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` via `/load-all` |
 
 ### When to Route Through /syner
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,10 @@ Content is rendered via [Fumadocs](https://fumadocs.dev) headless — `source.co
 | Scope | When | Pattern |
 |-------|------|---------|
 | None | Casual conversation | Respond directly |
-| Project | Syner-level context | `.syner/vaults/**/*.md` |
+| Project | Syner-level context | `.syner/vaults/**/*.md` + relevant `.syner/bookmarks/*.md` |
 | App | Task within one app | `.syner/vaults/{app}/**/*.md` |
-| Targeted | Specific file/topic | Glob/Grep for that area |
-| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` via `/load-all` |
+| Targeted | Specific file/topic | Glob/Grep for that area. Check bookmarks if topic matches. |
+| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` + `.syner/bookmarks/*.md` via `/load-all` |
 
 ### When to Route Through /syner
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ Content is rendered via [Fumadocs](https://fumadocs.dev) headless — `source.co
 | None | Casual conversation | Respond directly |
 | Project | Syner-level context | `.syner/vaults/**/*.md` |
 | App | Task within one app | `.syner/vaults/{app}/**/*.md` |
-| Targeted | Specific file/topic | Glob/Grep for that area |
-| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` via `/load-all` |
+| Targeted | Specific file/topic | Glob/Grep for that area + `.syner/bookmarks/*.md` if topic matches |
+| Full | Multi-domain synthesis | `.syner/vaults/**/*.md` + `.syner/bookmarks/*.md` via `/load-all` |
 
 ### When to Route Through /syner
 

--- a/apps/vaults/skills/load-all/SKILL.md
+++ b/apps/vaults/skills/load-all/SKILL.md
@@ -22,10 +22,11 @@ Build comprehensive understanding of the user's current state by reading all not
 
 ## Process
 
-### 1. Discover Vaults
+### 1. Discover Context Sources
 
 ```
-.syner/vaults/**/*.md    # All vaults (centralized)
+.syner/vaults/**/*.md      # All vaults (centralized, gitignored)
+.syner/bookmarks/*.md      # Curated external references (committed)
 ```
 
 This finds notes in:
@@ -34,6 +35,7 @@ This finds notes in:
 - `.syner/vaults/bot/` — bot context
 - `.syner/vaults/dev/` — development notes
 - Any other app with vaults under `.syner/vaults/{app}/`
+- `.syner/bookmarks/` — saved URLs with personal context and tags
 
 ### 2. Group by Level
 

--- a/skills/syner/SKILL.md
+++ b/skills/syner/SKILL.md
@@ -70,6 +70,12 @@ Vaults are gitignored (local > repo). Bookmarks are committed — they're curate
 
 **When to load bookmarks:** When the task overlaps with bookmark tags or topics. Don't load all bookmarks by default — check tags in frontmatter first, load only relevant ones.
 
+**How to check bookmarks:**
+1. `Glob(".syner/bookmarks/*.md")` to discover available bookmarks
+2. `Read` the first 10 lines of each (frontmatter with tags) — batch in parallel
+3. Match `tags` against the current task topic
+4. Load only the matched bookmarks fully
+
 ### How to Decide
 
 Ask yourself:

--- a/skills/syner/SKILL.md
+++ b/skills/syner/SKILL.md
@@ -53,19 +53,22 @@ Determine how much context this request needs:
 |-------|------|--------|
 | **None** | Casual conversation, greetings | Respond directly |
 | **App** | Task within a single app | Load that app's vault: `.syner/vaults/{app}/**/*.md` |
-| **Targeted** | Question about specific thing | Use Glob/Grep/Read for that area only |
-| **Full** | Multi-domain synthesis, needs complete picture | Call `Skill(skill="load-all")` |
+| **Targeted** | Question about specific thing | Use Glob/Grep/Read for that area only. Check bookmarks if topic matches. |
+| **Full** | Multi-domain synthesis, needs complete picture | Call `Skill(skill="load-all")`. Include relevant bookmarks. |
 
-### Vault Discovery
+### Context Sources
 
-Vaults exist at project and app levels. The filesystem IS the configuration:
+Vaults and bookmarks provide personal context. The filesystem IS the configuration:
 
 ```
-.syner/vaults/**/*.md           # All vaults (centralized)
+.syner/vaults/**/*.md           # All vaults (centralized, gitignored)
 .syner/vaults/{app}/**/*.md     # Single app's vaults
+.syner/bookmarks/*.md           # Saved URLs with personal context (committed)
 ```
 
-Local machine has more context than repo (vaults are gitignored by default).
+Vaults are gitignored (local > repo). Bookmarks are committed — they're curated external references with frontmatter tags.
+
+**When to load bookmarks:** When the task overlaps with bookmark tags or topics. Don't load all bookmarks by default — check tags in frontmatter first, load only relevant ones.
 
 ### How to Decide
 


### PR DESCRIPTION
## Summary

- Add `.syner/bookmarks/*.md` as a context source in `/syner` orchestrator
- Update CLAUDE.md context loading table to include bookmarks
- Bookmarks loaded proportionally: only when tags overlap with task topic

## Changes

**skills/syner/SKILL.md:**
- "Vault Discovery" → "Context Sources" — now includes bookmarks alongside vaults
- Guidance on when to load bookmarks (tag overlap, not by default)
- Updated context scope table for Targeted and Full modes

**CLAUDE.md:**
- Context loading table updated with bookmark patterns for Project, Targeted, and Full scopes

## Test plan

- [ ] Invoke `/syner` with a topic matching a bookmark tag → verify bookmark is loaded as context
- [ ] Invoke `/syner` with unrelated topic → verify bookmarks are NOT loaded

https://claude.ai/code/session_01Y2sm2YsjqyKPKHGXqZsshV